### PR TITLE
Unit tests and sequence containers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,8 @@
-cmake_minimum_required(VERSION 3.10.0)
+cmake_minimum_required(VERSION 3.24.0)
 project(graph VERSION 0.1.0 LANGUAGES CXX)
 
-# Define the project as a header-only library.
-add_library(graph INTERFACE)
-
-# Define the directory in which to search for includes
-# used in the library headers.
-target_include_directories(graph INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-)
-
-# Set the minimum C++ Standard against which to compile.
-target_compile_features(graph INTERFACE cxx_std_23)
+# Add subdirectory for the library
+add_subdirectory(include)
 
 # Add subdirectory for examples
 add_subdirectory(examples)
@@ -20,3 +10,8 @@ add_subdirectory(examples)
 # Install the library in the include directory of the
 # project linking it.
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION include)
+
+# Add tests
+include(CTest)
+enable_testing()
+add_subdirectory(tests)

--- a/examples/adjacency_list/adjacency_list.cpp
+++ b/examples/adjacency_list/adjacency_list.cpp
@@ -19,11 +19,10 @@
  * drop-in replacement.
  */
 
-#include "../containers/adapted_vector.h"
-
-#include "graph/graph.h"
-#include "graph/graph_algorithms.h"
-#include "graph/graph_traits.h"
+#include <graph/graph.h>
+#include <graph/graph_algorithms.h>
+#include <graph/graph_traits.h>
+#include <graph/sequence_containers.h>
 
 #include <iostream>
 #include <unordered_map>
@@ -54,7 +53,7 @@ void print(const auto& G)
 int main()
 {
     graph::graph <
-        graph::adjacency_list_policy <unsigned, char, char, std::unordered_map, AdaptedVector>
+        graph::adjacency_list_policy <unsigned, char, char, std::unordered_map, graph::vector>
         { .is_directed = true }
     > G = {
         {

--- a/examples/containers/adapted_vector.h
+++ b/examples/containers/adapted_vector.h
@@ -13,10 +13,10 @@
 #include <utility>
 #include <vector>
 
-template <typename T, class Alloc = std::allocator <T> >
-class AdaptedVector : public std::vector <T, Alloc>
+template <typename T, class Allocator = std::allocator <T> >
+class AdaptedVector : public std::vector <T, Allocator>
 {
-    using Base = std::vector <T, Alloc>;
+    using Base = std::vector <T, Allocator>;
 
     public:
         using Base::Base;

--- a/examples/containers/direct_address_table.h
+++ b/examples/containers/direct_address_table.h
@@ -205,7 +205,7 @@ namespace dat
                     /// assignment.
                     occupied.resize(key + 1, false);
                     occupied[key] = true;
-
+                    ++nmemb;
                     return {make_iterator(key), true};
                 }
 
@@ -232,7 +232,7 @@ namespace dat
 
                     occupied.resize(key + 1, false);
                     occupied[key] = true;
-
+                    ++nmemb;
                     return {make_iterator(key), true};
                 }
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Define the project as a header-only library.
+add_library(graph INTERFACE)
+
+# Define the directory in which to search for includes
+# used in the library headers.
+target_include_directories(graph INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+# Set the minimum C++ Standard against which to compile.
+target_compile_features(graph INTERFACE cxx_std_23)

--- a/include/graph/detail/adjacency_list/directed.h
+++ b/include/graph/detail/adjacency_list/directed.h
@@ -33,9 +33,6 @@ namespace graph
 
     template <auto Policy>
     class graph;
-
-    template <auto Policy>
-    class directed_graph;
     
 } // namespace graph
 
@@ -67,39 +64,10 @@ template <
     template <typename Key, typename T> class vCont,
     template <typename T> class eCont,
     graph::adjacency_list_policy <vId, vTp, eTp, vCont, eCont> Policy
-> requires (Policy.is_directed)
-class graph::graph <Policy> : public ::graph::directed_graph <Policy>
-{
-    using Class = graph;                                // The class.
-    using Base  = ::graph::directed_graph <Policy>;     // The base class.
-
-public:
-    using Base::Base;
-};
-
-template <
-    typename vId,
-    typename vTp,
-    typename eTp,
-    template <typename Key, typename T> class vCont,
-    template <typename T> class eCont,
-    graph::adjacency_list_policy <vId, vTp, eTp, vCont, eCont> Policy
-> requires (Policy.is_directed)
-struct graph::graph_traits <::graph::graph <Policy> >
-    : public ::graph::graph_traits <::graph::directed_graph <Policy> >
-{};
-
-template <
-    typename vId,
-    typename vTp,
-    typename eTp,
-    template <typename Key, typename T> class vCont,
-    template <typename T> class eCont,
-    graph::adjacency_list_policy <vId, vTp, eTp, vCont, eCont> Policy
 > requires (Policy.is_directed && Policy.is_multigraph && !Policy.support_inedge_iteration)
-class graph::directed_graph <Policy>
+class graph::graph <Policy>
 {
-    using Class = directed_graph;                       // The class.
+    using Class = graph;                       // The class.
 
     friend struct ::graph::graph_traits <Class>;
 
@@ -159,12 +127,12 @@ private:
 public:
     /// @section Constructors
 
-    constexpr directed_graph() = default;
+    constexpr graph() = default;
 
-    constexpr directed_graph(
+    constexpr graph(
         std::initializer_list <std::tuple <vId, vTp> > v_set,
         std::initializer_list <std::tuple <vId, vId, eTp> > e_set = {}
-    ) : directed_graph(v_set | std::views::all, e_set | std::views::all) {}
+    ) : graph(v_set | std::views::all, e_set | std::views::all) {}
     
     template <
         std::ranges::input_range VertexRange,
@@ -172,7 +140,7 @@ public:
     >
         requires std::convertible_to <std::ranges::range_reference_t <VertexRange>, std::tuple <vId, vTp> >
         && std::convertible_to <std::ranges::range_reference_t <EdgeRange>, std::tuple <vId, vId, eTp> >
-    constexpr directed_graph(VertexRange&& v_range, EdgeRange&& e_range = {})
+    constexpr graph(VertexRange&& v_range, EdgeRange&& e_range = {})
     {
         for (const auto& elem : v_range) {
             emplace_vertex(std::get <0>(elem), std::get <1>(elem));
@@ -583,7 +551,7 @@ class graph::detail::adjacency_list::vertex_view <Policy, V>::iterator_impl
 {
     using Class = iterator_impl;                        // The class.
 
-    friend class ::graph::directed_graph <Policy>;
+    friend class ::graph::graph <Policy>;
 
     template <bool OtherConst>
     friend class detail::adjacency_list::vertex_view <Policy, V>::sentinel_impl;
@@ -778,7 +746,7 @@ class graph::detail::adjacency_list::vertex_view <Policy, V>::sentinel_impl
 {
     using Class = sentinel_impl;                         // The class.
 
-    friend class ::graph::directed_graph <Policy>;
+    friend class ::graph::graph <Policy>;
 
 private:
     using base_sentinel_type = std::ranges::sentinel_t <std::conditional_t <Const, const V, V> >;
@@ -922,7 +890,7 @@ class graph::detail::adjacency_list::outedge_view <Policy, Iter>::iterator_impl
 {
     using Class = iterator_impl;                        // The class.
 
-    friend class ::graph::directed_graph <Policy>;
+    friend class ::graph::graph <Policy>;
 
     template <bool OtherConst>
     friend class detail::adjacency_list::outedge_view <Policy, Iter>::sentinel_impl;
@@ -1132,7 +1100,7 @@ class graph::detail::adjacency_list::outedge_view <Policy, Iter>::sentinel_impl
 {
     using Class = sentinel_impl;                         // The class.
 
-    friend class ::graph::directed_graph <Policy>;
+    friend class ::graph::graph <Policy>;
 
 private:
     using V = detail::views::all_t <decltype(std::get <1>(std::get <1>(*std::declval <Iter>())))>;
@@ -1244,7 +1212,7 @@ template <
     template <typename T> class eCont,
     graph::adjacency_list_policy <vId, vTp, eTp, vCont, eCont> Policy
 > requires (Policy.is_directed && !Policy.support_inedge_iteration)
-struct graph::graph_traits <::graph::directed_graph <Policy> >
+struct graph::graph_traits <::graph::graph <Policy> >
 {
     using policy_t = decltype(Policy);
     static constexpr policy_t policy = Policy;
@@ -1257,13 +1225,13 @@ struct graph::graph_traits <::graph::directed_graph <Policy> >
     using vertex_value_type     = std::tuple <const vId, vTp>;
     using edge_type             = eTp;
 
-    using vertex_iterator           = ::graph::directed_graph <Policy>::vertex_view_iterator_t;
-    using const_vertex_iterator     = ::graph::directed_graph <Policy>::vertex_view_const_iterator_t;
-    using outedge_iterator          = ::graph::directed_graph <Policy>::outedge_view_iterator_t;
-    using const_outedge_iterator    = ::graph::directed_graph <Policy>::outedge_view_const_iterator_t;
+    using vertex_iterator           = ::graph::graph <Policy>::vertex_view_iterator_t;
+    using const_vertex_iterator     = ::graph::graph <Policy>::vertex_view_const_iterator_t;
+    using outedge_iterator          = ::graph::graph <Policy>::outedge_view_iterator_t;
+    using const_outedge_iterator    = ::graph::graph <Policy>::outedge_view_const_iterator_t;
 
-    using size_type         = ::graph::directed_graph <Policy>::size_type;
-    using difference_type   = ::graph::directed_graph <Policy>::difference_type;
+    using size_type         = ::graph::graph <Policy>::size_type;
+    using difference_type   = ::graph::graph <Policy>::difference_type;
 };
 
 #pragma endregion   Graph traits

--- a/include/graph/graph.h
+++ b/include/graph/graph.h
@@ -12,11 +12,5 @@ namespace graph
 {
     template <auto Policy>
     class graph;
-
-    template <auto Policy>
-    class directed_graph;
-
-    template <auto Policy>
-    class undirected_graph;
     
 } // namespace graph

--- a/include/graph/sequence_containers.h
+++ b/include/graph/sequence_containers.h
@@ -1,0 +1,336 @@
+/**
+ * @file graph/sequence_containers.h
+ * 
+ * Wrapper classes for sequence containers.
+ */
+
+#pragma once
+
+#include <deque>
+#include <list>
+#include <memory>
+#include <ranges>
+#include <vector>
+
+namespace graph
+{
+    template <typename T, class Allocator = std::allocator <T> >
+    class vector;
+
+    template <typename T, class Allocator = std::allocator <T> >
+    class list;
+
+    template <typename T, class Allocator = std::allocator <T> >
+    class deque;
+    
+} // namespace graph
+
+/// @brief Wrapper around @c `std::vector` that provides default
+///        behaviour for @c `insert()` and related methods in the
+///        absence of a position argument.
+/// @tparam T Type of the elements stored.
+/// @tparam Allocator Allocator type.
+template <typename T, class Allocator>
+class graph::vector : public std::vector <T, Allocator>
+{
+    using Base = std::vector <T, Allocator>;
+    using Class = vector;
+
+public:
+    using Base::Base; // Inherit constructors
+    
+    using typename Base::size_type;
+    using typename Base::iterator;
+    using Base::insert;
+    using Base::emplace;
+    using Base::insert_range;
+
+    /// @brief Call @c `push_back()` on @c `value` and return an
+    ///        iterator to the newly inserted element.
+    /// @param value Element to insert into the container.
+    /// @return An iterator to the newly inserted element.
+    /// @exception Any exceptions thrown by @c `push_back()`.
+    constexpr iterator insert(const T& value)
+    {
+        Base::push_back(value);
+        return std::prev(Base::end());
+    }
+
+    /// @brief Call @c `push_back()` on @c `value` and return an
+    ///        iterator to the newly inserted element.
+    /// @param value Element to insert into the container.
+    /// @return An iterator to the newly inserted element.
+    /// @exception Any exceptions thrown by @c `push_back()`.
+    constexpr iterator insert(T&& value)
+    {
+        Base::push_back(std::move(value));
+        return std::prev(Base::end());
+    }
+
+    /// @brief Call @c `append_range()` on
+    ///        @c `std::ranges::subrange(first, last)`
+    ///        and return an iterator to
+    ///        the first newly inserted element.
+    /// @tparam Iter Iterator type that meets the requirements of
+    ///         an input iterator.
+    /// @param first Iterator to the first element in the range.
+    /// @param last Iterator to one past the last element in the range.
+    /// @return An iterator to the first newly inserted element.
+    /// @exception Any exceptions thrown by @c `append_range()`.
+    template <std::input_iterator Iter>
+    constexpr iterator insert(Iter first, Iter last)
+    {
+        return insert_range(std::ranges::subrange(first, last));
+    }
+
+    /// @brief Call @c `this->insert(this->end(), count, value)`.
+    /// @param count Number of copies of @c `value` to insert.
+    /// @param value Element to insert into the container.
+    /// @return An iterator to the first newly inserted element.
+    /// @exception Any exceptions thrown by @c `insert()`.
+    constexpr iterator insert(size_type count, const T& value)
+    {
+        return Base::insert(Base::end(), count, value);
+    }
+
+    /// @brief Call @c `this->insert(this->end(), ilist)`.
+    /// @param ilist Initializer list of elements to insert.
+    /// @return An iterator to the first newly inserted element.
+    /// @exception Any exceptions thrown by @c `insert()`.
+    constexpr iterator insert(std::initializer_list <T> ilist)
+    {
+        return Base::insert(Base::end(), ilist);
+    }
+
+    /// @brief Call @c `emplace_back()` on
+    ///        @c `std::forward <Args>(args)...`.
+    /// @tparam Args... Argument types to forward to @c `emplace_back()`.
+    /// @param args... Arguments to forward to @c `emplace_back()`.
+    /// @return An iterator to the newly inserted element.
+    /// @exception Any exceptions thrown by @c `emplace_back()`.
+    template <class... Args>
+    constexpr iterator emplace(Args&&... args)
+    {
+        Base::emplace_back(std::forward <Args>(args)...);
+        return std::prev(Base::end());
+    }
+
+    /// @brief Call @c `append_range()` on @c `std::forward <R>(range)`.
+    /// @tparam R Input range type.
+    /// @param range Input range of elements to insert.
+    /// @return An iterator to the first newly inserted element.
+    /// @exception Any exceptions thrown by @c `append_range()`.
+    template <std::ranges::input_range R>
+        requires std::convertible_to <std::ranges::range_reference_t <R>, T>
+    constexpr iterator insert_range(R&& range)
+    {
+        const auto size_before = Base::size();
+        append_range(std::forward <R>(range));
+        return Base::begin() + size_before;
+    }
+};
+
+/// @brief Wrapper around @c `std::list` that provides default
+///        behaviour for @c `insert()` and related methods in the
+///        absence of a position argument.
+/// @tparam T Type of the elements stored.
+/// @tparam Allocator Allocator type.
+template <typename T, class Allocator>
+class graph::list : public std::list <T, Allocator>
+{
+    using Base = std::list <T, Allocator>;
+    using Class = list;
+
+public:
+    using Base::Base; // Inherit constructors
+    
+    using typename Base::size_type;
+    using typename Base::iterator;
+    using Base::insert;
+    using Base::emplace;
+    using Base::insert_range;
+
+    /// @brief Call @c `push_back()` on @c `value` and return an
+    ///        iterator to the newly inserted element.
+    /// @param value Element to insert into the container.
+    /// @return An iterator to the newly inserted element.
+    /// @exception Any exceptions thrown by @c `push_back()`.
+    constexpr iterator insert(const T& value)
+    {
+        Base::push_back(value);
+        return std::prev(Base::end());
+    }
+
+    /// @brief Call @c `push_back()` on @c `value` and return an
+    ///        iterator to the newly inserted element.
+    /// @param value Element to insert into the container.
+    /// @return An iterator to the newly inserted element.
+    /// @exception Any exceptions thrown by @c `push_back()`.
+    constexpr iterator insert(T&& value)
+    {
+        Base::push_back(std::move(value));
+        return std::prev(Base::end());
+    }
+
+    /// @brief Call @c `append_range()` on
+    ///        @c `std::ranges::subrange(first, last)`
+    ///        and return an iterator to
+    ///        the first newly inserted element.
+    /// @tparam Iter Iterator type that meets the requirements of
+    ///         an input iterator.
+    /// @param first Iterator to the first element in the range.
+    /// @param last Iterator to one past the last element in the range.
+    /// @return An iterator to the first newly inserted element.
+    /// @exception Any exceptions thrown by @c `append_range()`.
+    template <std::input_iterator Iter>
+    constexpr iterator insert(Iter first, Iter last)
+    {
+        return insert_range(std::ranges::subrange(first, last));
+    }
+
+    /// @brief Call @c `this->insert(this->end(), count, value)`.
+    /// @param count Number of copies of @c `value` to insert.
+    /// @param value Element to insert into the container.
+    /// @return An iterator to the first newly inserted element.
+    /// @exception Any exceptions thrown by @c `insert()`.
+    constexpr iterator insert(size_type count, const T& value)
+    {
+        return Base::insert(Base::end(), count, value);
+    }
+
+    /// @brief Call @c `this->insert(this->end(), ilist)`.
+    /// @param ilist Initializer list of elements to insert.
+    /// @return An iterator to the first newly inserted element.
+    /// @exception Any exceptions thrown by @c `insert()`.
+    constexpr iterator insert(std::initializer_list <T> ilist)
+    {
+        return Base::insert(Base::end(), ilist);
+    }
+    
+    /// @brief Call @c `emplace_back()` on
+    ///        @c `std::forward <Args>(args)...`.
+    /// @tparam Args... Argument types to forward to @c `emplace_back()`.
+    /// @param args... Arguments to forward to @c `emplace_back()`.
+    /// @return An iterator to the newly inserted element.
+    /// @exception Any exceptions thrown by @c `emplace_back()`.
+    template <class... Args>
+    constexpr iterator emplace(Args&&... args)
+    {
+        Base::emplace_back(std::forward <Args>(args)...);
+        return std::prev(Base::end());
+    }
+
+    template <std::ranges::input_range R>
+        requires std::convertible_to <std::ranges::range_reference_t <R>, T>
+    constexpr iterator insert_range(R&& range)
+    {
+        const auto iter_before = std::prev(Base::end());
+        append_range(std::forward <R>(range));
+        return std::next(iter_before);
+    }
+};
+
+/// @brief Wrapper around @c `std::deque` that provides default
+///        behaviour for @c `insert()` and related methods in the
+///        absence of a position argument.
+/// @tparam T Type of the elements stored.
+/// @tparam Allocator Allocator type.
+template <typename T, class Allocator>
+class graph::deque : public std::deque <T, Allocator>
+{
+    using Base = std::deque <T, Allocator>;
+    using Class = deque;
+
+public:
+    using Base::Base; // Inherit constructors
+    
+    using typename Base::size_type;
+    using typename Base::iterator;
+    using Base::insert;
+    using Base::emplace;
+    using Base::insert_range;
+
+    /// @brief Call @c `push_back()` on @c `value` and return an
+    ///        iterator to the newly inserted element.
+    /// @param value Element to insert into the container.
+    /// @return An iterator to the newly inserted element.
+    /// @exception Any exceptions thrown by @c `push_back()`.
+    constexpr iterator insert(const T& value)
+    {
+        Base::push_back(value);
+        return std::prev(Base::end());
+    }
+
+    /// @brief Call @c `push_back()` on @c `value` and return an
+    ///        iterator to the newly inserted element.
+    /// @param value Element to insert into the container.
+    /// @return An iterator to the newly inserted element.
+    /// @exception Any exceptions thrown by @c `push_back()`.
+    constexpr iterator insert(T&& value)
+    {
+        Base::push_back(std::move(value));
+        return std::prev(Base::end());
+    }
+
+    /// @brief Call @c `append_range()` on
+    ///        @c `std::ranges::subrange(first, last)`
+    ///        and return an iterator to
+    ///        the first newly inserted element.
+    /// @tparam Iter Iterator type that meets the requirements of
+    ///         an input iterator.
+    /// @param first Iterator to the first element in the range.
+    /// @param last Iterator to one past the last element in the range.
+    /// @return An iterator to the first newly inserted element.
+    /// @exception Any exceptions thrown by @c `append_range()`.
+    template <std::input_iterator Iter>
+    constexpr iterator insert(Iter first, Iter last)
+    {
+        return insert_range(std::ranges::subrange(first, last));
+    }
+
+    /// @brief Call @c `this->insert(this->end(), count, value)`.
+    /// @param count Number of copies of @c `value` to insert.
+    /// @param value Element to insert into the container.
+    /// @return An iterator to the first newly inserted element.
+    /// @exception Any exceptions thrown by @c `insert()`.
+    constexpr iterator insert(size_type count, const T& value)
+    {
+        return Base::insert(Base::end(), count, value);
+    }
+
+    /// @brief Call @c `this->insert(this->end(), ilist)`.
+    /// @param ilist Initializer list of elements to insert.
+    /// @return An iterator to the first newly inserted element.
+    /// @exception Any exceptions thrown by @c `insert()`.
+    constexpr iterator insert(std::initializer_list <T> ilist)
+    {
+        return Base::insert(Base::end(), ilist);
+    }
+    
+    /// @brief Call @c `emplace_back()` on
+    ///        @c `std::forward <Args>(args)...`.
+    /// @tparam Args... Argument types to forward to @c `emplace_back()`.
+    /// @param args... Arguments to forward to @c `emplace_back()`.
+    /// @return An iterator to the newly inserted element.
+    /// @exception Any exceptions thrown by @c `emplace_back()`.
+    template <class... Args>
+    constexpr iterator emplace(Args&&... args)
+    {
+        Base::emplace_back(std::forward <Args>(args)...);
+        return std::prev(Base::end());
+    }
+
+    /// @brief Call @c `append_range()` on @c `std::forward <R>(range)`.
+    /// @tparam R Input range type.
+    /// @param range Input range of elements to insert.
+    /// @return An iterator to the first newly inserted element.
+    /// @exception Any exceptions thrown by @c `append_range()`.
+    template <std::ranges::input_range R>
+        requires std::convertible_to <std::ranges::range_reference_t <R>, T>
+    constexpr iterator insert_range(R&& range)
+    {
+        const auto iter_before = std::prev(Base::end());
+        append_range(std::forward <R>(range));
+        return std::next(iter_before);
+    }
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.24.0)
+
+include(FetchContent)
+
+# GoogleTest
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        52eb8108c5bdec04579160ae17225d66034bd723 # v1.17.0
+  FIND_PACKAGE_ARGS NAMES GTest                           # Try `find_package` first
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE) # For Windows: Prevent overriding the parent project's compiler/linker settings
+FetchContent_MakeAvailable(googletest)
+
+add_executable(gtest_test gtest_test.cpp adjacency_list/directed_multigraph.cpp)
+
+target_link_options(gtest_test PRIVATE --coverage)
+target_compile_options(gtest_test PRIVATE --coverage)
+
+target_link_libraries(gtest_test PRIVATE GTest::gtest_main graph gcov)
+target_compile_features(gtest_test PRIVATE cxx_std_17)
+
+include(GoogleTest)
+gtest_discover_tests(gtest_test)

--- a/tests/adjacency_list/adapted_vector.h
+++ b/tests/adjacency_list/adapted_vector.h
@@ -1,0 +1,70 @@
+/**
+ * @file tests/adjacency_list/adapted_vector.h
+ * 
+ * Wrapper around @c `std::vector` providing an interface
+ * compatible with @c `graph::adjacency_list` as an edge
+ * container (as defined in its @c `graph_traits` specialisation).
+ */
+
+#pragma once
+
+#include <memory>
+#include <ranges>
+#include <utility>
+#include <vector>
+
+template <typename T, class Allocator = std::allocator <T> >
+class AdaptedVector : public std::vector <T, Allocator>
+{
+    using Base = std::vector <T, Allocator>;
+
+    public:
+        using Base::Base;
+
+        constexpr AdaptedVector(const Base& base)
+            : Base{base}
+        {}
+
+        constexpr AdaptedVector(Base&& base)
+            : Base{std::move(base)}
+        {}
+
+        constexpr auto insert(const std::ranges::range_value_t <Base>& elem)
+        {
+            this->push_back(elem);
+            auto it = this->end();
+            return --it;
+        }
+
+        constexpr auto insert(std::ranges::range_value_t <Base>&& elem)
+        {
+            this->emplace_back(std::move(elem));
+            auto it = this->end();
+            return --it;
+        }
+        
+        template <std::input_iterator It>
+        constexpr auto insert(It first, It last)
+        {
+            const auto insert_position = this->size();
+            this->append_range(std::ranges::subrange(first, last));
+            return this->begin() + insert_position;
+        }
+
+        template <std::ranges::input_range R>
+            requires std::convertible_to <std::ranges::range_reference_t <R>, T>
+        constexpr auto insert_range(R&& range)
+        {
+            const auto insert_position = this->size();
+            this->append_range(std::forward <R>(range));
+            return this->begin() + insert_position;
+        }
+
+        template <class... Args>
+        constexpr auto emplace(Args&&... args)
+        {
+            this->emplace_back(std::forward <Args>(args)...);
+            auto it = this->end();
+            return --it;
+        }
+};

--- a/tests/adjacency_list/direct_address_table.h
+++ b/tests/adjacency_list/direct_address_table.h
@@ -1,0 +1,727 @@
+/**
+ * @file direct_address_table.h
+ * 
+ * Header-only implementation of a direct-address table.
+ * 
+ * @cite Thomas H. Cormen, Charles E. Leiserson, Ronald L. Rivest,
+ *       and Clifford Stein. 2009. Introduction to Algorithms, Fourth
+ *       Edition (4th. ed.), pp. 273-274. The MIT Press.
+ * 
+ * @link https://github.com/anirudh-bijay/direct-address-table
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <concepts>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#if __cpp_lib_ranges >= 202202L
+
+#include <ranges>
+
+#endif
+
+namespace dat
+{
+    template <
+        std::unsigned_integral Key,
+        typename T,
+        class Allocator = std::allocator <T>
+    >
+    class direct_address_table
+    {
+        public:
+            using key_type                  = Key;
+            using mapped_type               = T;
+            using value_type                = std::pair <const key_type, mapped_type>;
+            using allocator_type            = Allocator;
+
+            static_assert(std::same_as <
+                typename std::allocator_traits <allocator_type>::value_type,
+                mapped_type
+            >, "Allocator should have value type T");
+
+            using mapped_container_type     = std::vector <mapped_type, allocator_type>;
+            using size_type                 = typename mapped_container_type::size_type;
+            using difference_type           = typename mapped_container_type::difference_type;
+
+            class iterator;
+            class const_iterator;
+            using reverse_iterator          = std::reverse_iterator <iterator>;
+            using const_reverse_iterator    = std::reverse_iterator <const_iterator>;
+
+            using reference                 = std::iter_reference_t <iterator>;
+            using const_reference           = std::iter_reference_t <const_iterator>;
+            using pointer                   = std::iterator_traits <iterator>::pointer;
+            using const_pointer             = std::iterator_traits <const_iterator>::pointer;
+            
+            static_assert(std::same_as <const_reference, std::iter_const_reference_t <iterator> >);
+
+            using key_equal                 = std::equal_to <key_type>;
+
+        private:
+            using bool_allocator_type       = typename std::allocator_traits <allocator_type>::rebind_alloc <bool>;
+
+        protected:
+            mapped_container_type mapped_container{};
+            std::vector <bool, bool_allocator_type> occupied{};
+            size_type nmemb = 0;
+
+        private:
+            constexpr iterator
+            make_iterator(const key_type index) noexcept
+            { return iterator(this, index); }
+
+            constexpr const_iterator
+            make_const_iterator(const key_type index) const noexcept
+            { return const_iterator(this, index); }
+
+        public:
+            constexpr direct_address_table() = default;
+
+            constexpr direct_address_table(const allocator_type& alloc)
+                requires std::constructible_from <bool_allocator_type, allocator_type>
+                : mapped_container(alloc), occupied(bool_allocator_type(alloc)) {}
+
+            constexpr direct_address_table(const allocator_type& alloc)
+                requires (!std::constructible_from <bool_allocator_type, allocator_type>)
+                : mapped_container(alloc), occupied{} {}
+
+            template <std::input_iterator Iter>
+            constexpr direct_address_table(Iter first, Iter last)
+            {
+                insert(first, last);
+            }
+
+            constexpr direct_address_table(std::initializer_list <value_type> ilist)
+                : direct_address_table(ilist.begin(), ilist.end()) {}
+
+#if __cpp_lib_containers_ranges >= 202202L
+
+            template <std::ranges::input_range R>
+                requires std::convertible_to <std::ranges::range_reference_t <R>, value_type>
+            constexpr direct_address_table(std::from_range_t, R&& range)
+            {
+                insert_range(std::forward <R>(range));
+            }
+
+#endif
+
+            constexpr direct_address_table&
+            operator=(std::initializer_list <value_type> ilist)
+            {
+                clear();
+                insert(ilist.begin(), ilist.end());
+                return *this;
+            }
+
+            template <std::input_iterator InputIt>
+            constexpr void insert(InputIt first, const InputIt last)
+            {
+                if constexpr (std::forward_iterator <InputIt>) {
+                    /// Avoid multiple reallocations by determining the maximum
+                    /// key value beforehand, then performing a single
+                    /// reallocation if necessary.
+
+                    const key_type max_key = value_type(*std::max_element(
+                        first, last, [](const value_type& l, const value_type& r) {
+                            return l.first < r.first;
+                        })
+                    ).first;
+
+                    const size_type new_size = mapped_container.size() > max_key + 1
+                        ? mapped_container.size()
+                        : max_key + 1;
+
+                    mapped_container.resize(new_size);
+                    occupied.resize(new_size, false);
+
+                    for (; first != last; ++first) {
+                        value_type value(*first);
+                        mapped_container[value.first] = value.second;
+                        if (!occupied[value.first]) {
+                            occupied[value.first] = true;
+                            ++nmemb;
+                        }
+                    }
+                } else {
+                    /// Make repeated calls to @c `emplace`.
+
+                    for (; first != last; ++first) {
+                        emplace(*first);
+                    }
+                }
+            }
+
+            constexpr std::pair <iterator, bool>
+            insert(const value_type& value)
+            {
+                return emplace(value);
+            }
+
+            constexpr std::pair <iterator, bool>
+            insert(value_type&& value)
+            {
+                return emplace(std::move(value));
+            }
+
+            template <class... Args> requires std::is_constructible_v <value_type, Args...>
+            constexpr std::pair <iterator, bool>
+            emplace(Args&&... args)
+            {
+                value_type value(std::forward <Args>(args)...);
+                return try_emplace(std::move(value.first), std::move(value.second));
+            }
+
+            template <typename M> requires std::is_assignable_v <mapped_type&, M>
+            constexpr std::pair <iterator, bool>
+            insert_or_assign(const key_type& key, M&& obj)
+            {
+                /// @note This pattern will be followed in other insertion
+                ///       methods as well.
+                if (key >= mapped_container.size()) {
+                    /// We must avoid default-construction at the key
+                    /// where insertion will occur.
+                    mapped_container.reserve(key + 1);
+                    mapped_container.resize(key);
+                    mapped_container.emplace_back(std::forward <M>(obj));
+
+                    /// We do not do so for @c `occupied` since the
+                    /// unnecessary initial assignment of @c `false`
+                    /// to @c `occupied[key]` can easily be optimised
+                    /// out by the compiler without side effects.
+                    /// 
+                    /// Moreover, even with zero optimisation, the cost
+                    /// of making two assignments to the internal size
+                    /// counter exceeds the cost of an extra @c `bool`
+                    /// assignment.
+                    occupied.resize(key + 1, false);
+                    occupied[key] = true;
+                    ++nmemb;
+                    return {make_iterator(key), true};
+                }
+
+                mapped_container[key] = std::forward <M>(obj);
+
+                if (occupied[key]) {
+                    return {make_iterator(key), false};
+                } else {
+                    occupied[key] = true;
+                    ++nmemb;
+                    return {make_iterator(key), true};
+                }
+            }
+
+            template <class... Args>
+            constexpr std::pair <iterator, bool>
+            try_emplace(const key_type& key, Args&&... args)
+            {
+                if (key >= mapped_container.size()) {
+                    /// See @c `insert` for justification.
+                    mapped_container.reserve(key + 1);
+                    mapped_container.resize(key);
+                    mapped_container.emplace_back(std::forward <Args>(args)...);
+
+                    occupied.resize(key + 1, false);
+                    occupied[key] = true;
+                    ++nmemb;
+                    return {make_iterator(key), true};
+                }
+
+                if (occupied[key]) {
+                    return {make_iterator(key), false};
+                } else {
+                    mapped_container[key] = mapped_type(std::forward <Args>(args)...);
+                    occupied[key] = true;
+                    ++nmemb;
+                    return {make_iterator(key), true};
+                }
+            }
+
+#if __cpp_lib_containers_ranges >= 202202L
+
+            template <std::ranges::input_range R>
+                requires std::convertible_to <std::ranges::range_reference_t <R>, value_type>
+            constexpr void insert_range(R&& range)
+            {
+                if constexpr (std::ranges::forward_range <R>) {
+                    /// Avoid multiple reallocations by determining the maximum
+                    /// key value beforehand, then performing a single
+                    /// reallocation if necessary.
+
+                    const key_type max_key = value_type(*std::ranges::max_element(
+                        range, [](const value_type& l, const value_type& r) {
+                            return l.first < r.first;
+                        })
+                    ).first;
+
+                    const size_type new_size = mapped_container.size() > max_key + 1
+                        ? mapped_container.size()
+                        : max_key + 1;
+
+                    mapped_container.resize(new_size);
+                    occupied.resize(new_size, false);
+
+                    for (auto&& elem : std::forward <R>(range)) {
+                        value_type value(elem);
+                        mapped_container[value.first] = value.second;
+                        if (!occupied[value.first]) {
+                            occupied[value.first] = true;
+                            ++nmemb;
+                        }
+                    }
+                } else {
+                    /// Make repeated calls to @c `emplace`.
+
+                    for (auto&& elem : std::forward <R>(range)) {
+                        emplace(elem);
+                    }
+                }
+            }
+
+#endif
+            
+            constexpr iterator erase(const const_iterator pos)
+            {
+                const auto next_pos = make_iterator(std::get <0>(*std::next(pos)));
+
+                assert(occupied[std::get <0>(*pos)] == true);
+                occupied[std::get <0>(*pos)] = false;
+                --nmemb;
+
+                return next_pos;
+            }
+
+            constexpr size_type erase(const key_type& key)
+            {
+                if (occupied[key]) {
+                    occupied[key] = false;
+                    --nmemb;
+                    return 1;
+                }
+
+                return 0;
+            }
+
+            constexpr void clear() noexcept
+            {
+                mapped_container.clear();
+                occupied.clear();
+                nmemb = 0;
+            }
+
+            constexpr iterator begin() noexcept
+            {
+                return make_iterator(std::find(occupied.cbegin(), occupied.cend(), true) - occupied.cbegin());
+            }
+
+            constexpr const_iterator begin() const noexcept
+            {
+                return make_const_iterator(std::find(occupied.cbegin(), occupied.cend(), true) - occupied.cbegin());
+            }
+
+            constexpr const_iterator cbegin() const noexcept
+            {
+                return begin();
+            }
+
+            constexpr iterator end() noexcept
+            {
+                return make_iterator(mapped_container.size());
+            }
+
+            constexpr const_iterator end() const noexcept
+            {
+                return make_const_iterator(mapped_container.size());
+            }
+
+            constexpr const_iterator cend() const noexcept
+            {
+                return end();
+            }
+
+            constexpr iterator rbegin() noexcept
+            {
+                return std::make_reverse_iterator(end());
+            }
+
+            constexpr const_iterator rbegin() const noexcept
+            {
+                return std::make_reverse_iterator(end());
+            }
+
+            constexpr const_iterator crbegin() const noexcept
+            {
+                return rbegin();
+            }
+
+            constexpr iterator rend() noexcept
+            {
+                return std::make_reverse_iterator(begin());
+            }
+
+            constexpr const_iterator rend() const noexcept
+            {
+                return std::make_reverse_iterator(begin());
+            }
+
+            constexpr const_iterator crend() const noexcept
+            {
+                return rend();
+            }
+
+            constexpr allocator_type get_allocator() const noexcept
+            {
+                return mapped_container.get_allocator();
+            }
+
+            constexpr size_type size() const noexcept
+            {
+                return nmemb;
+            }
+
+            constexpr bool empty() const noexcept
+            {
+                return size() == 0;
+            }
+
+            constexpr size_type max_size() const noexcept
+            {
+                return std::min(mapped_container.max_size(), occupied.max_size());
+            }
+
+            constexpr size_type capacity() const noexcept
+            {
+                return std::min(mapped_container.capacity(), occupied.capacity());
+            }
+
+            constexpr void reserve(const size_type max_key)
+            {
+                mapped_container.reserve(max_key + 1);
+                occupied.reserve(max_key + 1);
+            }
+
+            constexpr void shrink_to_fit()
+            {
+                mapped_container.shrink_to_fit();
+                occupied.shrink_to_fit();
+            }
+
+            constexpr mapped_type& operator[](const key_type& key)
+            {
+                return try_emplace(key).first->second;
+            }
+
+            constexpr mapped_type& at(const key_type& key)
+            {
+                if (!contains(key)) {
+                    throw std::out_of_range("Key not in table");
+                }
+
+                return mapped_container[key];
+            }
+
+            constexpr const mapped_type& at(const key_type& key) const
+            {
+                if (!contains(key)) {
+                    throw std::out_of_range("Key not in table");
+                }
+
+                return mapped_container[key];
+            }
+
+            constexpr iterator find(const key_type& key) noexcept
+            {
+                return contains(key) ? make_iterator(key) : end();
+            }
+
+            constexpr const_iterator find(const key_type& key) const noexcept
+            {
+                return contains(key) ? make_const_iterator(key) : cend();
+            }
+
+            constexpr bool contains(const key_type& key) const noexcept
+            {
+                return key < occupied.size() && occupied[key];
+            }
+
+            constexpr size_type count(const key_type& key) const noexcept
+            {
+                return contains(key);
+            }
+    
+            constexpr std::pair <iterator, iterator>
+            equal_range(const key_type& key) noexcept
+            {
+                if (contains(key)) {
+                    return {make_iterator(key), std::next(make_iterator(key))};
+                } else {
+                    return {end(), end()};
+                }
+            }
+
+            constexpr std::pair <const_iterator, const_iterator>
+            equal_range(const key_type& key) const noexcept
+            {
+                if (contains(key)) {
+                    return {make_const_iterator(key), std::next(make_const_iterator(key))};
+                } else {
+                    return {cend(), cend()};
+                }
+            }
+    };
+
+    template <
+        std::unsigned_integral Key,
+        typename T,
+        class Allocator
+    >
+    constexpr bool operator==(const direct_address_table <Key, T, Allocator>& lhs,
+                              const direct_address_table <Key, T, Allocator>& rhs) noexcept
+    {
+        if (lhs.size() != rhs.size())
+            return false;
+
+        const auto ei = lhs.cend(), ej = rhs.cend();
+        for (auto i = lhs.cbegin(); i != ei; ++i) {
+            const auto j = rhs.find(std::get <0>(*i));
+            
+            if (j == ej || std::get <1>(*i) != std::get <1>(*j))
+                return false;
+        }
+
+        return true;
+    }
+
+    template <
+        std::unsigned_integral Key,
+        typename T,
+        class Allocator,
+        class Pred
+    >
+    constexpr typename direct_address_table <Key, T, Allocator>::size_type
+    erase_if(direct_address_table <Key, T, Allocator>& c, Pred pred)
+    {
+        const auto old_size = c.size();
+        for (auto first = c.begin(), last = c.end(); first != last;)
+        {
+            if (pred(*first)) {
+                first = c.erase(first);
+            } else {
+                ++first;
+            }
+        }
+
+        return old_size - c.size();
+    }
+
+    template <
+        std::unsigned_integral Key,
+        typename T,
+        class Allocator
+    >
+    class direct_address_table <Key, T, Allocator>::iterator
+    {
+        private:
+            direct_address_table <Key, T, Allocator>* c_ptr;
+            key_type key_;
+
+        public:
+            using difference_type   = direct_address_table::difference_type;
+            using value_type        = direct_address_table::value_type; // `std::pair <const key_type, mapped_type>`
+            using reference         = std::pair <const key_type&, mapped_type&>;
+            using const_reference   = std::pair <const key_type&, const mapped_type&>;
+            using iterator_concept  = std::bidirectional_iterator_tag;
+
+            class [[nodiscard]] pointer
+            {
+                private:
+                    reference ref;
+
+                public:
+                    explicit constexpr pointer(reference ref) noexcept : ref{std::move(ref)} {}
+
+                    constexpr reference operator*() const noexcept
+                    {
+                        return ref;
+                    }
+
+                    constexpr const reference* operator->() const noexcept
+                    {
+                        return std::addressof(ref);
+                    }
+            };
+
+            constexpr iterator() noexcept = default;
+
+            explicit constexpr iterator(
+                direct_address_table <Key, T, Allocator> * const c_ptr,
+                const key_type& key
+            ) noexcept : c_ptr(c_ptr), key_(key) {}
+
+            constexpr operator const_iterator() const noexcept
+            {
+                return const_iterator(c_ptr, key_);
+            }
+
+            constexpr key_type key() const noexcept
+            {
+                return key_;
+            }
+
+            constexpr reference operator*() const noexcept
+            {
+                return {key_, c_ptr->mapped_container[key_]};
+            }
+
+            constexpr pointer operator->() const noexcept
+            {
+                return pointer{**this};
+            }
+
+            constexpr iterator& operator++()
+            {
+                while (++key_ < c_ptr->mapped_container.size() && !c_ptr->occupied[key_]);
+
+                return *this;
+            }
+
+            constexpr iterator operator++(int)
+            {
+                const iterator copy(*this);
+                ++*this;
+                return copy;
+            }
+
+            constexpr iterator& operator--()
+            {
+                while (key_-- /* --key_ + 1 */ > 0 && !c_ptr->occupied[key_]);
+                
+                return *this;
+            }
+
+            constexpr iterator operator--(int)
+            {
+                const iterator copy(*this);
+                --*this;
+                return copy;
+            }
+
+            friend constexpr std::strong_ordering
+            operator<=>(const iterator& lhs, const iterator& rhs) noexcept
+            {
+                assert(lhs.c_ptr == rhs.c_ptr);
+                return lhs.key_ <=> rhs.key_;
+            }
+
+            friend constexpr bool
+            operator==(const iterator& lhs, const iterator& rhs) noexcept = default;
+    };
+
+    template <
+        std::unsigned_integral Key,
+        typename T,
+        class Allocator
+    >
+    class direct_address_table <Key, T, Allocator>::const_iterator
+    {
+        private:
+            const direct_address_table* c_ptr;
+            key_type key_;
+
+        public:
+            using difference_type   = direct_address_table::difference_type;
+            using value_type        = direct_address_table::value_type; // `std::pair <const key_type, mapped_type>`
+            using reference         = std::pair <const key_type&, const mapped_type&>;
+            using const_reference   = std::pair <const key_type&, const mapped_type&>;
+            using iterator_concept  = std::bidirectional_iterator_tag;
+
+            class [[nodiscard]] pointer
+            {
+                private:
+                    reference ref;
+
+                public:
+                    explicit constexpr pointer(reference ref) noexcept : ref{std::move(ref)} {}
+
+                    constexpr reference operator*() const noexcept
+                    {
+                        return ref;
+                    }
+
+                    constexpr const reference* operator->() const noexcept
+                    {
+                        return std::addressof(ref);
+                    }
+            };
+
+            constexpr const_iterator() noexcept = default;
+
+            explicit constexpr const_iterator(
+                const direct_address_table * const c_ptr,
+                const key_type& key
+            ) noexcept : c_ptr(c_ptr), key_(key) {}
+
+            constexpr key_type key() const noexcept
+            {
+                return key_;
+            }
+
+            constexpr reference operator*() const noexcept
+            {
+                return {key_, c_ptr->mapped_container[key_]};
+            }
+
+            constexpr pointer operator->() const
+            {
+                return pointer{**this};
+            }
+
+            constexpr const_iterator& operator++()
+            {
+                while (++key_ < c_ptr->mapped_container.size() && !c_ptr->occupied[key_]);
+
+                return *this;
+            }
+
+            constexpr const_iterator operator++(int)
+            {
+                const const_iterator copy(*this);
+                ++*this;
+                return copy;
+            }
+
+            constexpr const_iterator& operator--()
+            {
+                while (key_-- /* --key_ + 1 */ > 0 && !c_ptr->occupied[key_]);
+                
+                return *this;
+            }
+
+            constexpr const_iterator operator--(int)
+            {
+                const const_iterator copy(*this);
+                --*this;
+                return copy;
+            }
+
+            friend constexpr std::strong_ordering
+            operator<=>(const const_iterator& lhs, const const_iterator& rhs) noexcept
+            {
+                assert(lhs.c_ptr == rhs.c_ptr);
+                return lhs.key_ <=> rhs.key_;
+            }
+            
+            friend constexpr bool
+            operator==(const const_iterator& lhs, const const_iterator& rhs) noexcept = default;
+    };
+
+} // namespace dat

--- a/tests/adjacency_list/directed_multigraph.cpp
+++ b/tests/adjacency_list/directed_multigraph.cpp
@@ -1,0 +1,115 @@
+/**
+ * @file tests/adjacency_list/directed_multigraph.cpp
+ */
+
+#include "direct_address_table.h"
+
+#include <gtest/gtest.h>
+#include <graph/graph.h>
+#include <graph/sequence_containers.h>
+
+#include <map>
+#include <ranges>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+namespace
+{
+    TEST(DirectedAdjacencyListMultigraph, TemplateParameters)
+    {
+        /// @brief Test the directed multigraph with template parameters.
+        
+        // Create a directed multigraph (with unsupported edge list type `std::vector`)
+        graph::graph <
+            graph::adjacency_list_policy <
+                int, std::string, std::pair <int, int>, std::unordered_map, std::vector
+            >{
+                .is_directed = true,
+                .is_multigraph = true,
+                .forbid_self_loops = false,
+                .support_inedge_iteration = false
+            }
+        > g1;
+
+        struct Empty {};
+
+        // Create a directed multigraph (with unsupported edge list type `std::vector`)
+        // using an empty vertex data type and edge weight type.
+        graph::graph <
+            graph::adjacency_list_policy <
+                int, Empty, Empty, std::map, std::vector
+            >{
+                .is_directed = true,
+                .is_multigraph = true,
+                .forbid_self_loops = false,
+                .support_inedge_iteration = false
+            }
+        > g2;
+    }
+
+    TEST(DirectedAdjacencyListMultigraph, Constructors)
+    {
+        /// @section Test construction from initializer lists.
+        
+        graph::graph <
+            graph::adjacency_list_policy <
+                int, std::string, std::pair <int, int>, std::unordered_map, graph::vector
+            >{
+                .is_directed = true,
+                .is_multigraph = true,
+                .forbid_self_loops = false,
+                .support_inedge_iteration = false
+            }
+        > g1{
+            {{1, "A"}, {2, "B"}, {3, "C"}},
+            {{1, 2, {1, 2}}, {2, 3, {2, 3}}, {1, 3, {1, 3}}}
+        };
+
+        // Constexpr construction
+        // Expects the constexpr member function `size()` to be defined.
+        constexpr auto size = graph::graph <
+            graph::adjacency_list_policy <
+                unsigned, std::string, std::pair <int, int>, dat::direct_address_table, graph::vector
+            >{
+                .is_directed = true,
+                .is_multigraph = true,
+                .forbid_self_loops = false,
+                .support_inedge_iteration = false
+            }
+        >{
+            {{1, "A"}, {2, "B"}, {3, "C"}},
+            {{1, 2, {1, 2}}, {2, 3, {2, 3}}, {1, 3, {1, 3}}}
+        }.size();
+
+        /// @section Test construction from range.
+        graph::graph <
+            graph::adjacency_list_policy <
+                int, std::string, std::pair <int, int>, std::unordered_map, graph::vector
+            >{
+                .is_directed = true,
+                .is_multigraph = true,
+                .forbid_self_loops = false,
+                .support_inedge_iteration = false
+            }
+        > g2{
+            std::vector {std::make_pair(1, "A"), {2, "B"}, {3, "C"}}
+        };
+
+        /// @section Test construction from range.
+        graph::graph <
+            graph::adjacency_list_policy <
+                int, std::string, char, std::unordered_map, graph::vector
+            >{
+                .is_directed = true,
+                .is_multigraph = true,
+                .forbid_self_loops = false,
+                .support_inedge_iteration = false
+            }
+        > g3{
+            std::vector {std::make_pair(1, "A"), {2, "B"}, {3, "C"}},
+            std::vector {std::make_tuple(1, 2, 'a'), {2, 3, 'b'}, {1, 3, 'c'}, {1, 1, 'd'}, {1, 3, 'e'}}
+        };
+    }
+}

--- a/tests/adjacency_list/directed_multigraph.cpp
+++ b/tests/adjacency_list/directed_multigraph.cpp
@@ -1,5 +1,7 @@
 /**
  * @file tests/adjacency_list/directed_multigraph.cpp
+ * 
+ * @brief Unit tests for the directed adjacency list multigraph implementation.
  */
 
 #include "direct_address_table.h"
@@ -97,7 +99,6 @@ namespace
             std::vector {std::make_pair(1, "A"), {2, "B"}, {3, "C"}}
         };
 
-        /// @section Test construction from range.
         graph::graph <
             graph::adjacency_list_policy <
                 int, std::string, char, std::unordered_map, graph::vector
@@ -111,5 +112,85 @@ namespace
             std::vector {std::make_pair(1, "A"), {2, "B"}, {3, "C"}},
             std::vector {std::make_tuple(1, 2, 'a'), {2, 3, 'b'}, {1, 3, 'c'}, {1, 1, 'd'}, {1, 3, 'e'}}
         };
+    }
+
+    TEST(DirectedAdjacencyListMultigraph, InsertionMethods)
+    {
+        /// @section Set up a directed multigraph with initial vertices and edges.
+
+        graph::graph <
+            graph::adjacency_list_policy <
+                int, std::string, std::pair <int, int>, std::unordered_map, graph::vector
+            >{
+                .is_directed = true,
+                .is_multigraph = true,
+                .forbid_self_loops = false,
+                .support_inedge_iteration = false
+            }
+        > g{
+            {{1, "A"}, {2, "B"}, {3, "C"}},
+            {{1, 2, {1, 2}}, {2, 3, {2, 3}}}
+        };
+
+        // Check whether vertex and edge counts are correct.
+        ASSERT_EQ(g.order(), 3);
+        ASSERT_EQ(g.size(), 2);
+
+        /// @section Test vertex insertion.
+
+        auto v_iter = g.insert_vertex({4, "D"});
+        ASSERT_EQ(std::get <0>(*v_iter), 4);
+        EXPECT_EQ(std::get <1>(*v_iter), "D");
+        ASSERT_EQ(g.order(), 4);
+        ASSERT_EQ(g.size(), 2);
+
+        EXPECT_TRUE(g.outedges(v_iter).empty());
+
+        v_iter = g.emplace_vertex(5, "E");
+        ASSERT_EQ(std::get <0>(*v_iter), 5);
+        EXPECT_EQ(std::get <1>(*v_iter), "E");
+        ASSERT_EQ(g.order(), 5);
+        ASSERT_EQ(g.size(), 2);
+
+        EXPECT_TRUE(g.outedges(v_iter).empty());
+
+        auto v = std::make_pair(6, "F");
+        v_iter = g.insert_vertex(v);
+        ASSERT_EQ(std::get <0>(*v_iter), 6);
+        EXPECT_EQ(std::get <1>(*v_iter), "F");
+        ASSERT_EQ(g.order(), 6);
+        ASSERT_EQ(g.size(), 2);
+
+        EXPECT_TRUE(g.outedges(v_iter).empty());
+
+        /// @section Test edge insertion.
+
+        auto e = std::make_tuple(1, 2, std::make_pair(1, 2));
+        g.insert_edge({1, 2, {1, 2}});
+        g.insert_edge({2, 3, {2, 3}});
+        auto e_iter = g.insert_edge({1, 3, {1, 3}});
+
+        EXPECT_EQ(g.order(), 6);
+        EXPECT_EQ(g.size(), 5);
+
+        ASSERT_EQ(*e_iter, std::make_tuple(1, 3, std::make_tuple(1, 3)));
+
+        /// @section Test self-loop insertion.
+
+        e_iter = g.insert_edge(v_iter, v_iter, {6, 6});
+
+        EXPECT_EQ(g.order(), 6);
+        EXPECT_EQ(g.size(), 6);
+
+        ASSERT_EQ(*e_iter, std::make_tuple(6, 6, std::make_tuple(6, 6)));
+
+        /// @section Test edge insertion with emplace.
+
+        e_iter = g.emplace_edge(4, 5, std::pair{4, 5});
+
+        EXPECT_EQ(g.order(), 6);
+        EXPECT_EQ(g.size(), 7);
+
+        ASSERT_EQ(*e_iter, std::make_tuple(4, 5, std::make_pair(4, 5)));
     }
 }

--- a/tests/gtest_test.cpp
+++ b/tests/gtest_test.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+// Demonstrate some basic assertions.
+TEST(HelloTest, BasicAssertions) {
+  // Expect two strings not to be equal.
+  EXPECT_STRNE("hello", "world");
+  // Expect equality.
+  EXPECT_EQ(7 * 6, 42);
+}


### PR DESCRIPTION
# Unit tests and sequence containers

This PR introduces unit tests using GoogleTest and sets up CTest to identify and run them. Additionally, wrappers around the standard sequence containers (`std::vector`, `std::deque`, and `std::list`) are provided in the `graph` namespace to conform to interface requirements.

As part of the process, CMake files have been refactored. Further, `direct_address_table.h` has undergone bug fixes. Moreover, the directionality of edges (unidirectional/bidirectional) will be specified only through policy settings; redundant class templates, such as `graph::directed_graph` and `graph::undirected_graph`, are removed.

### Summary

| File | Description |
| ---- | ----------- |
| tests/gtest_test.cpp | Basic GoogleTest demonstration test |
| tests/adjacency_list/directed_multigraph.cpp | Base for comprehensive unit tests for [include/graph/detail/adjacency_list/directed.h](include/graph/detail/adjacency_list/directed.h) |
| tests/adjacency_list/direct_address_table.h | Direct address table implementation for graph storage |
| tests/adjacency_list/adapted_vector.h | **Redundant** |
| tests/CMakeLists.txt | CMake configuration for GoogleTest and test compilation |
| include/graph/sequence_containers.h | Wrapper classes for standard sequence containers |
| include/graph/graph.h | Removal of redundant graph class declarations |
| include/graph/detail/adjacency_list/directed.h | Refactoring from `directed_graph` to unified `graph` class |
| include/CMakeLists.txt | Library definition and build configuration (moved out of root [CMakeLists.txt](CMakeLists.txt)) |
| examples/containers/direct_address_table.h | Bug fixes to member count tracking |
| examples/containers/adapted_vector.h | **Ready for removal** |
| examples/adjacency_list/adjacency_list.cpp | Updated to use new sequence container wrappers from the `graph` namespace |
| CMakeLists.txt | Project restructuring with test integration |